### PR TITLE
Add missing schools to departmentCodeMapping.

### DIFF
--- a/departmentCodeMapping.js
+++ b/departmentCodeMapping.js
@@ -1,13 +1,16 @@
 module.exports = {
   A: 'ABE',
   B: 'BIO',
+  C: 'CBH',
   D: 'CSC',
   E: 'EES',
   H: 'STH',
   I: 'ICT',
+  J: 'EECS',
   K: 'CHE',
   L: 'ECE',
   M: 'ITM',
   S: 'SCI',
-  U: 'UF'
+  U: 'UF',
+  V: 'GVS'
 }


### PR DESCRIPTION
Maybe the department code mapping should really be deprecated, but as long as it exists, it should be complete.

This is part of https://trello.com/c/44HjE9JE .